### PR TITLE
Add Rate of Change Symbol to User Stats Text Messages

### DIFF
--- a/src/MyTimerTrigger.cs
+++ b/src/MyTimerTrigger.cs
@@ -163,7 +163,7 @@ namespace Spca.Function
         public void SendText(string number, string message)
         {
             MessageResource.Create(
-                body: $"[Beta Testing]\n\n{message}",
+                body: message,
                 from: new Twilio.Types.PhoneNumber(MyTimerTrigger.TWILIO_PHONE),
                 to: new Twilio.Types.PhoneNumber(number)
             );

--- a/src/UserStatsCollection.cs
+++ b/src/UserStatsCollection.cs
@@ -5,6 +5,7 @@
     using System;
     using System.Collections.Generic;
     using System.Text;
+    using Twilio.TwiML.Voice;
 
     public class UserStatsCollection
     {
@@ -51,19 +52,87 @@
         /// <returns></returns>
         public string GetTimeBoundedUserStatsString(int lookback)
         {
-            int startIndex = 0;
-            int endIndex = this._userStatsList.Count - 1;
-            DateTime maxLookbackTime = MyTimerTrigger.RunTime.AddDays(-1 * lookback);
+            // Retrieve the time-bounded user stats pertaining to the previous lookback period.
+            // For example, if the lookback period is one day, gather stats from between (2d .. 1d).
+            // The sole purpose of this is to supply previous values to the method generating up / down rate of change arrows.
+            TimeBoundedUserStats prevBoundedUserStats = this.getTimeBoundedUserStatsStringAux(
+                MyTimerTrigger.RunTime.AddDays(-2 * lookback),
+                MyTimerTrigger.RunTime.AddDays(-1 * lookback));
 
+            // Retrieve the time-bounded user stats pertaining to the current lookback period.
+            TimeBoundedUserStats currBoundedUserStats = this.getTimeBoundedUserStatsStringAux(
+                MyTimerTrigger.RunTime.AddDays(-1 * lookback),
+                MyTimerTrigger.RunTime);
+
+            int playersBagged = currBoundedUserStats.PlayersBagged;
+            int matchesPlayed = currBoundedUserStats.MatchesPlayed;
+            int minutesPlayed = currBoundedUserStats.MinutesPlayed;
+            int top25 = currBoundedUserStats.Top25;
+            int top10 = currBoundedUserStats.Top10;
+            int top5 = currBoundedUserStats.Top5;
+            int top3 = currBoundedUserStats.Top3;
+            int top1 = currBoundedUserStats.Top1;
+            double kd = currBoundedUserStats.Kd;
+            double km = currBoundedUserStats.Km;
+
+            // When a user has only top 1 placements and at least 1 player bagged, display an inifinity sign to make them feel special.
+            string kdString = matchesPlayed == top1 && matchesPlayed > 0 && playersBagged > 0 ? "\u221E" : Math.Round(kd, 2).ToString();
+
+            StringBuilder sb = new StringBuilder();
+
+            // Append all of the stats to the string builder.
+            sb.AppendLine($"Username: {this._username}");
+            sb.AppendLine($"Players Bagged: {playersBagged} {this.getRateOfChangeArrow(prevBoundedUserStats.PlayersBagged, currBoundedUserStats.PlayersBagged)}");
+            sb.AppendLine($"K/D: {kdString} {this.getRateOfChangeArrow(prevBoundedUserStats.Kd, currBoundedUserStats.Kd)}");
+            sb.AppendLine($"K/Min: {Math.Round(km, 2)} {this.getRateOfChangeArrow(prevBoundedUserStats.Km, currBoundedUserStats.Km)}");
+            sb.AppendLine($"Matches Played: {matchesPlayed} {this.getRateOfChangeArrow(prevBoundedUserStats.MatchesPlayed, currBoundedUserStats.MatchesPlayed)}");
+            sb.AppendLine($"Minutes Played: {minutesPlayed} ({Math.Abs(Math.Round(minutesPlayed / (double)60, 1))} hours) {this.getRateOfChangeArrow(prevBoundedUserStats.MinutesPlayed, currBoundedUserStats.MinutesPlayed)}");
+            sb.AppendLine($"Top 1: {top1} {this.getRateOfChangeArrow(prevBoundedUserStats.Top1, currBoundedUserStats.Top1)}");
+            sb.AppendLine($"Top 3: {top3} {this.getRateOfChangeArrow(prevBoundedUserStats.Top3, currBoundedUserStats.Top3)}");
+            sb.AppendLine($"Top 5: {top5} {this.getRateOfChangeArrow(prevBoundedUserStats.Top5, currBoundedUserStats.Top5)}");
+            sb.AppendLine($"Top 10: {top10} {this.getRateOfChangeArrow(prevBoundedUserStats.Top10, currBoundedUserStats.Top10)}");
+            sb.AppendLine($"Top 25: {top25} {this.getRateOfChangeArrow(prevBoundedUserStats.Top25, currBoundedUserStats.Top25)}");
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Constructs a TimeBoundedUserStats object encompassing the user's stats within a certain time range.
+        /// </summary>
+        /// <param name="startTime">Earliest stat time to use in calculations.</param>
+        /// <param name="endTime">Latest stat time to use in calculations.</param>
+        /// <returns>TimeBoundedUserStats object.</returns>
+        private TimeBoundedUserStats getTimeBoundedUserStatsStringAux(DateTime startTime, DateTime endTime)
+        {
+            int startIndex = 0;
+            int endIndex = 0;
+
+            // Find the first user statistic index for the time period.
             foreach (UserStats userStats in this._userStatsList)
             {
-                if (userStats.Timestamp >= maxLookbackTime)
+                if (userStats.Timestamp >= startTime)
                 {
-                    // Break out of loop as soon as the first record within the lookback time is found.
                     break;
                 }
 
                 startIndex++;
+            }
+
+            // Find the last user statistic index for the time period.
+            for (int i = 0; i < this._userStatsList.Count; i++)
+            {
+                if (this._userStatsList[i].Timestamp <= endTime && i == this._userStatsList.Count - 1)
+                {
+                    break;
+                }
+                else if (this._userStatsList[i].Timestamp <= endTime)
+                {
+                    endIndex++;
+                }
+                else
+                {
+                    break;
+                }
             }
 
             // Initialize stats as negative. These should only be negative when a user has no previous table entries.
@@ -78,47 +147,113 @@
             double kd = -1.0;
             double km = -1.0;
 
-            StringBuilder sb = new StringBuilder();
-
-            // Calculate stats when there's more than one entry.
-            if (startIndex != endIndex && endIndex != -1)
+            // Calculate stats when there's more than one entry in the Azure database.
+            if (startIndex < endIndex)
             {
                 ModeStats aggregateMode0 = this._userStatsList[startIndex].AggregateModeStats;
                 ModeStats aggregateMode1 = this._userStatsList[endIndex].AggregateModeStats;
-                
-                playersBagged = aggregateMode1.PlayersBagged - aggregateMode0.PlayersBagged;
-                matchesPlayed = aggregateMode1.MatchesPlayed - aggregateMode0.MatchesPlayed;
-                minutesPlayed = aggregateMode1.MinutesPlayed - aggregateMode0.MinutesPlayed;
-                km = playersBagged / (double)minutesPlayed;
-                top25 = aggregateMode1.Top25 - aggregateMode0.Top25;
-                top10 = aggregateMode1.Top10 - aggregateMode0.Top10;
-                top5 = aggregateMode1.Top5 - aggregateMode0.Top5;
-                top3 = aggregateMode1.Top3 - aggregateMode0.Top3;
-                top1 = aggregateMode1.Top1 - aggregateMode0.Top1;
 
-                if (matchesPlayed - top1 > 0)
+                if (aggregateMode0.MatchesPlayed < aggregateMode1.MatchesPlayed)
                 {
-                    kd = playersBagged / (double)(matchesPlayed - top1);
+                    // Update stats from -1 only when a user has played at least one game. 
+                    playersBagged = aggregateMode1.PlayersBagged - aggregateMode0.PlayersBagged;
+                    matchesPlayed = aggregateMode1.MatchesPlayed - aggregateMode0.MatchesPlayed;
+                    minutesPlayed = aggregateMode1.MinutesPlayed - aggregateMode0.MinutesPlayed;
+                    top25 = aggregateMode1.Top25 - aggregateMode0.Top25;
+                    top10 = aggregateMode1.Top10 - aggregateMode0.Top10;
+                    top5 = aggregateMode1.Top5 - aggregateMode0.Top5;
+                    top3 = aggregateMode1.Top3 - aggregateMode0.Top3;
+                    top1 = aggregateMode1.Top1 - aggregateMode0.Top1;
+
+                    if (matchesPlayed - top1 > 0)
+                    {
+                        // K/D is calculated by the number of players bagged divided by the number of non-top 1 placements.
+                        kd = playersBagged / (double)(matchesPlayed - top1);
+                    }
+
+                    km = playersBagged / (double)minutesPlayed;
                 }
             }
 
-            // When a user has only top 1 placements and at least 1 player bagged, display an inifinity sign to make them feel special.
-            string kdString = matchesPlayed == top1 && matchesPlayed > 0 && playersBagged > 0 ? "\u221E" : Math.Round(kd, 2).ToString();
+            return new TimeBoundedUserStats(playersBagged, matchesPlayed, minutesPlayed, kd, km, top1, top3, top5, top10, top25);
+        }
 
-            // Append all of the stats to the string builder.
-            sb.AppendLine($"Username: {this._username}");
-            sb.AppendLine($"Players Bagged: {playersBagged}");
-            sb.AppendLine($"K/D: {kdString}");
-            sb.AppendLine($"K/Min: {Math.Round(km, 2)}");
-            sb.AppendLine($"Matches Played: {matchesPlayed}");
-            sb.AppendLine($"Minutes Played: {minutesPlayed} ({Math.Abs(Math.Round(minutesPlayed / (double)60, 1))} hours)");
-            sb.AppendLine($"Top 1: {top1}");
-            sb.AppendLine($"Top 3: {top3}");
-            sb.AppendLine($"Top 5: {top5}");
-            sb.AppendLine($"Top 10: {top10}");
-            sb.AppendLine($"Top 25: {top25}");
+        /// <summary>
+        /// Gets the rate of change arrow (up or down) depending on the change between the previous value and the current value.
+        /// </summary>
+        /// <param name="prevVal">Previous value.</param>
+        /// <param name="currVal">Current value.</param>
+        /// <returns>Rate of change arrow (up or down) in unicode format.</returns>
+        private string getRateOfChangeArrow(double prevVal, double currVal)
+        {
+            if (currVal > prevVal)
+            {
+                // Up arrow.
+                return "\u2191";
+            }
+            else if (currVal == prevVal)
+            {
+                return "=";
+            }
+            else
+            {
+                // Down arrow.
+                return "\u2193";
+            }
+        }
 
-            return sb.ToString();
+        /// <summary>
+        /// Class representing essential player stats within a certain timeframe.
+        /// </summary>
+        private class TimeBoundedUserStats
+        {
+            public int PlayersBagged { get; set; }
+            public int MatchesPlayed { get; set; }
+            public int MinutesPlayed { get; set; }
+            public double Kd { get; set; }
+            public double Km { get; set; }
+            public int Top1 { get; set; }
+            public int Top3 { get; set; }
+            public int Top5 { get; set; }
+            public int Top10 { get; set; }
+            public int Top25 { get; set; }
+
+            /// <summary>
+            /// Constructs a TimeBoundedUserStats object.
+            /// </summary>
+            /// <param name="playersBagged">Number of players "bagged".</param>
+            /// <param name="matchesPlayed">Number of matches played.</param>
+            /// <param name="minutesPlayed">Number of minutes played.</param>
+            /// <param name="kd">Players bagged to non-top 1 placement ratio.</param>
+            /// <param name="km">Number of players bagged per minute.</param>
+            /// <param name="top1">Number of top 1 placements.</param>
+            /// <param name="top3">Number of top 3 placements.</param>
+            /// <param name="top5">Number of top 5 placements.</param>
+            /// <param name="top10">Number of top 10 placements.</param>
+            /// <param name="top25">Number of top 25 placements.</param>
+            public TimeBoundedUserStats(
+                int playersBagged,
+                int matchesPlayed,
+                int minutesPlayed,
+                double kd,
+                double km,
+                int top1,
+                int top3,
+                int top5,
+                int top10,
+                int top25)
+            {
+                this.PlayersBagged = playersBagged;
+                this.MatchesPlayed = matchesPlayed;
+                this.MinutesPlayed = minutesPlayed;
+                this.Kd = kd;
+                this.Km = km;
+                this.Top1 = top1;
+                this.Top3 = top3;
+                this.Top5 = top5;
+                this.Top10 = top10;
+                this.Top25 = top25;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Adding a rate of change symbol to the user stats text message. These symbols include an up/down arrow and an equal sign (for no change). The current rate of change is based on (2*lookback) worth of summation data.